### PR TITLE
Add Free/Pro plan badges to feature pages

### DIFF
--- a/pages/features/checkboxes.mdx
+++ b/pages/features/checkboxes.mdx
@@ -4,7 +4,7 @@ The Check Box component allows users to select multiple options from a predefine
 
 ---
 
-- **Multiple Selections ** – Users can check one or more options.
+- **Multiple Selections** – Users can check one or more options.
 - **“Other” Option** – Allows users to specify a custom response.
 - **Flexible Customization** – Adjust label text, default selections, and styles.
 

--- a/pages/features/conditional-logic.mdx
+++ b/pages/features/conditional-logic.mdx
@@ -6,16 +6,19 @@ Create dynamic, personalized form experiences by showing different content based
 
 ---
 
+<div style={{ backgroundColor: '#ecfdf5', border: '2px solid #10b981', borderRadius: '0.5rem', padding: '1rem', marginTop: '1.5rem', marginBottom: '1.5rem', display: 'flex', gap: '0.75rem', alignItems: 'flex-start' }}>
+  <div style={{ fontSize: '1.5rem', lineHeight: '1' }}>🎁</div>
+  <div style={{ flex: '1' }}>
+    <span style={{ color: '#065f46', fontSize: '0.95rem' }}>Conditional logic is available for <strong>free</strong> to all Makeform users.</span>
+  </div>
+</div>
+
 **What you can do with conditional logic:**
 
 - ✅ Route respondents to different pages based on their answers
 - ✅ Create branching paths for quizzes, surveys, and assessments
 - ✅ Skip irrelevant sections automatically
 - ✅ Build complex multi-path forms without multiple separate forms
-
-<Callout type="info">
-Conditional logic is available on all plans.
-</Callout>
 
 ---
 

--- a/pages/features/custom-domain.mdx
+++ b/pages/features/custom-domain.mdx
@@ -4,6 +4,13 @@ import { Callout } from 'nextra/components'
 
 Use your own domain for your forms instead of the default makeform.ai domain.
 
+<div style={{ backgroundColor: '#fdf2f8', border: '2px solid #ec4899', borderRadius: '0.5rem', padding: '1rem', marginTop: '1.5rem', marginBottom: '1.5rem', display: 'flex', gap: '0.75rem', alignItems: 'flex-start' }}>
+  <div style={{ fontSize: '1.5rem', lineHeight: '1' }}>✨</div>
+  <div style={{ flex: '1' }}>
+    <span style={{ color: '#831843', fontSize: '0.95rem' }}>Custom domains is a <a href="/plans-and-pricing" style={{ textDecoration: 'underline', color: '#831843' }}><strong>Makeform Pro</strong></a> feature.</span>
+  </div>
+</div>
+
 ---
 
 **What you get with custom domains:**
@@ -11,10 +18,6 @@ Use your own domain for your forms instead of the default makeform.ai domain.
 - ✅ Professional branded form URLs (e.g., `forms.yourcompany.com`)
 - ✅ Automatic SSL certificates for secure HTTPS connections
 - ✅ Quick setup with just one CNAME record
-
-<Callout type="info">
-Custom domains is a **Pro feature**.
-</Callout>
 
 ---
 

--- a/pages/features/email-notifications.mdx
+++ b/pages/features/email-notifications.mdx
@@ -4,8 +4,15 @@ import { Callout } from 'nextra/components';
 
 Currently, only form creators (owners) can receive email notifications or track responses.
 
+<div style={{ backgroundColor: '#ecfdf5', border: '2px solid #10b981', borderRadius: '0.5rem', padding: '1rem', marginTop: '1.5rem', marginBottom: '1.5rem', display: 'flex', gap: '0.75rem', alignItems: 'flex-start' }}>
+  <div style={{ fontSize: '1.5rem', lineHeight: '1' }}>🎁</div>
+  <div style={{ flex: '1' }}>
+    <span style={{ color: '#065f46', fontSize: '0.95rem' }}>Email notifications are available for <strong>free</strong> to all Makeform users.</span>
+  </div>
+</div>
+
 <Callout type="info">
-Features allowing respondents to receive automated emails or personalized responses are still under 
+Features allowing respondents to receive automated emails or personalized responses are still under
 development and will be available in a future update.
 </Callout>
 

--- a/pages/features/file-upload.mdx
+++ b/pages/features/file-upload.mdx
@@ -2,6 +2,13 @@
 
 File Upload allows users to upload files to your form with configurable file type and size restrictions.
 
+<div style={{ backgroundColor: '#ecfdf5', border: '2px solid #10b981', borderRadius: '0.5rem', padding: '1rem', marginTop: '1.5rem', marginBottom: '1.5rem', display: 'flex', gap: '0.75rem', alignItems: 'flex-start' }}>
+  <div style={{ fontSize: '1.5rem', lineHeight: '1' }}>🎁</div>
+  <div style={{ flex: '1' }}>
+    <span style={{ color: '#065f46', fontSize: '0.95rem' }}>File uploads are available for <strong>free</strong> to all Makeform users (10 MB per file limit).</span>
+  </div>
+</div>
+
 ## 📌 How It Looks in the Form Builder
 
 ![File Upload Selection](/images/file_upload1.png)

--- a/pages/features/geo-capture.mdx
+++ b/pages/features/geo-capture.mdx
@@ -4,6 +4,13 @@ Geo Capture automatically detects and captures the user's geographic location (c
 
 import { Callout } from 'nextra/components'
 
+<div style={{ backgroundColor: '#ecfdf5', border: '2px solid #10b981', borderRadius: '0.5rem', padding: '1rem', marginTop: '1.5rem', marginBottom: '1.5rem', display: 'flex', gap: '0.75rem', alignItems: 'flex-start' }}>
+  <div style={{ fontSize: '1.5rem', lineHeight: '1' }}>🎁</div>
+  <div style={{ flex: '1' }}>
+    <span style={{ color: '#065f46', fontSize: '0.95rem' }}>Geo Capture is available for <strong>free</strong> to all Makeform users.</span>
+  </div>
+</div>
+
 <Callout type="info">
 **Note:** Geo Capture is hidden by default. Users won't see this field in the form - it's automatically populated in the background.
 </Callout>

--- a/pages/features/hidden-fields.mdx
+++ b/pages/features/hidden-fields.mdx
@@ -3,6 +3,13 @@
 Hidden fields allow you to pass existing data through your form URL directly into your form.
 This helps you personalize the experience for respondents and provides deeper insights from the responses you collect.
 
+<div style={{ backgroundColor: '#ecfdf5', border: '2px solid #10b981', borderRadius: '0.5rem', padding: '1rem', marginTop: '1.5rem', marginBottom: '1.5rem', display: 'flex', gap: '0.75rem', alignItems: 'flex-start' }}>
+  <div style={{ fontSize: '1.5rem', lineHeight: '1' }}>🎁</div>
+  <div style={{ flex: '1' }}>
+    <span style={{ color: '#065f46', fontSize: '0.95rem' }}>Hidden fields are available for <strong>free</strong> to all Makeform users.</span>
+  </div>
+</div>
+
 ---
 
 # What is a hidden field in Makeform?
@@ -10,8 +17,8 @@ This helps you personalize the experience for respondents and provides deeper in
 A hidden field lets you track respondents by associating form submissions with user-specific data, such as user ID or email. It’s completely invisible to respondents, yet it enables you to effectively track users and analyze responses.
 
 With Makeform, hidden fields specifically help you:
-• Track submissions by associating responses with user IDs or emails.
-• Accurately identify users for deeper insights into your form analytics.
+- Track submissions by associating responses with user IDs or emails.
+- Accurately identify users for deeper insights into your form analytics.
 
 ---
 

--- a/pages/features/remove-makeform-branding.mdx
+++ b/pages/features/remove-makeform-branding.mdx
@@ -3,11 +3,15 @@ import Link from 'next/link'
 
 # Remove Makeform branding
 
-Makeform have a “Powered by MakeForm” button on every page of your form. With Makeform Pro,
+Makeform have a "Powered by MakeForm" button on every page of your form. With Makeform Pro,
 you can remove all Makeform branding and have your forms seamlessly represent your brand.
-<Callout type="warning">
-Removing Makeform branding is a <Link href="https://www.makeform.ai/#pricing" className="underline">Makeform Pro feature</Link>
-</Callout>
+
+<div style={{ backgroundColor: '#fdf2f8', border: '2px solid #ec4899', borderRadius: '0.5rem', padding: '1rem', marginTop: '1.5rem', marginBottom: '1.5rem', display: 'flex', gap: '0.75rem', alignItems: 'flex-start' }}>
+  <div style={{ fontSize: '1.5rem', lineHeight: '1' }}>✨</div>
+  <div style={{ flex: '1' }}>
+    <span style={{ color: '#831843', fontSize: '0.95rem' }}>Remove Makeform branding is a <a href="/plans-and-pricing" style={{ textDecoration: 'underline', color: '#831843' }}><strong>Makeform Pro</strong></a> feature.</span>
+  </div>
+</div>
 
 <div className="shadow-2xl mt-12">
   ![Remove Branding Example1](/images/remove-branding1.png)

--- a/pages/features/share-setting.mdx
+++ b/pages/features/share-setting.mdx
@@ -2,6 +2,13 @@
 
 You can customize the link text and meta information of your form.
 
+<div style={{ backgroundColor: '#fdf2f8', border: '2px solid #ec4899', borderRadius: '0.5rem', padding: '1rem', marginTop: '1.5rem', marginBottom: '1.5rem', display: 'flex', gap: '0.75rem', alignItems: 'flex-start' }}>
+  <div style={{ fontSize: '1.5rem', lineHeight: '1' }}>✨</div>
+  <div style={{ flex: '1' }}>
+    <span style={{ color: '#831843', fontSize: '0.95rem' }}>Customizing form link previews is a <a href="/plans-and-pricing" style={{ textDecoration: 'underline', color: '#831843' }}><strong>Makeform Pro</strong></a> feature.</span>
+  </div>
+</div>
+
 <div className="shadow-2xl mt-12">
   ![Sharing Setting Example1](/images/share-setting1.png)
 </div>

--- a/pages/features/signature.mdx
+++ b/pages/features/signature.mdx
@@ -2,6 +2,13 @@
 
 Signature allows users to provide a digital signature using a drawing canvas directly in your form.
 
+<div style={{ backgroundColor: '#ecfdf5', border: '2px solid #10b981', borderRadius: '0.5rem', padding: '1rem', marginTop: '1.5rem', marginBottom: '1.5rem', display: 'flex', gap: '0.75rem', alignItems: 'flex-start' }}>
+  <div style={{ fontSize: '1.5rem', lineHeight: '1' }}>🎁</div>
+  <div style={{ flex: '1' }}>
+    <span style={{ color: '#065f46', fontSize: '0.95rem' }}>Signature input is available for <strong>free</strong> to all Makeform users.</span>
+  </div>
+</div>
+
 ## 📌 How It Looks in the Form Builder
 
 ![Signature Selection](/images/signature1.png)

--- a/pages/guides/form-templates.mdx
+++ b/pages/guides/form-templates.mdx
@@ -1,5 +1,12 @@
 ## Form Templates
 
+<div style={{ backgroundColor: '#ecfdf5', border: '2px solid #10b981', borderRadius: '0.5rem', padding: '1rem', marginTop: '1.5rem', marginBottom: '1.5rem', display: 'flex', gap: '0.75rem', alignItems: 'flex-start' }}>
+  <div style={{ fontSize: '1.5rem', lineHeight: '1' }}>🎁</div>
+  <div style={{ flex: '1' }}>
+    <span style={{ color: '#065f46', fontSize: '0.95rem' }}>You can use any templates in our library for <strong>free</strong>.</span>
+  </div>
+</div>
+
 - You can choose a template for your form from a bunch of templates by clicking on the `Templates` button.
   ![Template Button](/images/template_button.png)
 


### PR DESCRIPTION
## Summary

Add prominent plan requirement badges to feature documentation pages to help users quickly identify which features are available on Free vs Pro plans.

### Free Features (Green badges with 🎁)
- Conditional logic
- Email notifications  
- File uploads (10 MB limit)
- Hidden fields
- Signature input
- Geo capture
- Form templates

### Pro Features (Pink badges with ✨)
- Custom domains
- Remove Makeform branding
- Customize form link previews

### Badge Design
- **Free badges**: Green/teal background with gift icon
- **Pro badges**: Pink background with sparkles icon, "Makeform Pro" links to pricing page
- Positioned prominently at the top of each feature page
- Distinct colors for easy visual identification

### Additional Fixes
- Fix typo in checkboxes.mdx (multiple selections bold formatting)
- Fix list formatting in hidden-fields.mdx (use proper markdown list syntax)

## Test Plan
- [ ] Verify all badges display correctly with proper colors
- [ ] Test "Makeform Pro" link navigates to pricing page
- [ ] Check badge text formatting (bold, underline)
- [ ] Ensure no conflicts with existing page content

🤖 Generated with [Claude Code](https://claude.com/claude-code)