### PR TITLE
Add Plausible analytics for traffic monitoring

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,11 +1,18 @@
 import '../styles.css'
 import { GoogleAnalytics } from '@next/third-parties/google'
+import Script from 'next/script'
 
 export default function Nextra({ Component, pageProps }) {
   return (
     <>
       <Component {...pageProps} />
       <GoogleAnalytics gaId={'G-5QNPN82FR3'} />
+      <Script
+        defer
+        data-domain="makeform.ai"
+        src="https://plausible.nilni.com/js/script.outbound-links.js"
+        strategy="afterInteractive"
+      />
     </>
   )
 }


### PR DESCRIPTION
## Summary
- Add Plausible analytics script to track help center traffic
- Uses Next.js Script component with `afterInteractive` strategy for optimal loading
- Tracks outbound links via `script.outbound-links.js`

## Test plan
- [ ] Verify script loads in browser DevTools (Network tab shows 200 status)
- [ ] Confirm `window.plausible` function exists in browser console
- [ ] Check pageview events are sent to Plausible (POST to `/api/event` returns 202)

🤖 Generated with [Claude Code](https://claude.com/claude-code)