### PR TITLE
Remove 5% application fee from payment docs

### DIFF
--- a/pages/features/payment.mdx
+++ b/pages/features/payment.mdx
@@ -9,7 +9,7 @@ Collect payments directly through your forms with secure Stripe integration. Acc
 <div style={{ backgroundColor: '#ecfdf5', border: '2px solid #10b981', borderRadius: '0.5rem', padding: '1rem', marginTop: '1.5rem', marginBottom: '1.5rem', display: 'flex', gap: '0.75rem', alignItems: 'flex-start' }}>
   <div style={{ fontSize: '1.5rem', lineHeight: '1' }}>🎁</div>
   <div style={{ flex: '1' }}>
-    <span style={{ color: '#065f46', fontSize: '0.95rem' }}>Payment collection is available for <strong>free</strong> to all Makeform users with a 5% application fee. <a href="/plans-and-pricing" style={{ textDecoration: 'underline', color: '#065f46' }}><strong>Pro users</strong></a> pay 0% application fee.</span>
+    <span style={{ color: '#065f46', fontSize: '0.95rem' }}>Payment collection is completely <strong>free</strong> for all Makeform users. Makeform does not charge any fees — only standard Stripe processing fees apply.</span>
   </div>
 </div>
 
@@ -75,12 +75,7 @@ If you don't have a Stripe account yet, you can create one for free during the c
 
 ## Payment fees
 
-Makeform charges an application fee on top of standard Stripe payment processing fees:
-
-- **Free plan**: 5% application fee
-- **Pro plan**: 0% application fee (no markup)
-
-**Stripe's standard processing fees** apply to all transactions:
+Makeform does not charge any additional fees for payment collection. Only standard Stripe processing fees apply:
 - 2.9% + $0.30 per successful card charge (US)
 - Fees vary by country and payment method
 


### PR DESCRIPTION
## Summary
- Removed the 5% application fee from payment documentation — payment collection is now completely free for all users
- Updated the callout banner and "Payment fees" section to reflect that only standard Stripe processing fees apply
- Removed Free/Pro tier fee distinction since there is no longer a Makeform markup

## Test plan
- [ ] Verify the payment page renders correctly at `/help/features/payment`
- [ ] Confirm the green callout box shows updated "completely free" messaging
- [ ] Confirm the "Payment fees" section no longer mentions 5% or plan tiers
- [ ] Check no broken links or formatting issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)